### PR TITLE
\left \right before vertical bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $$
   \text{If } \aleph_\omega \text{ is a strong limit cardinal, then } 2 ^ {\aleph_ \omega} < \aleph_ {\omega_4}.
 $$
 
-Whether the $4$ in $\aleph_ {\omega_4}$ is an artifact of the proof or the best possible bound is a major open problem. In the language of PCF theory, this is the question of whether (in certain sets of cardinals $A$) the known bound $|\text{pcf}(A)| < |A|^{+4}$ is tight, or if $|A|^{+4}$ can be reduced. Currently it is not even known if $|\text{pcf}(A)| \ne |A|$ is possible.
+Whether the $4$ in $\aleph_ {\omega_4}$ is an artifact of the proof or the best possible bound is a major open problem. In the language of PCF theory, this is the question of whether (in certain sets of cardinals $A$) the known bound $\left|\text{pcf}(A)\right| < \left|A\right|^{+4}$ is tight, or if $\left|A\right|^{+4}$ can be reduced. Currently it is not even known if $\left|\text{pcf}(A)\right| \ne \left|A\right|$ is possible.
 
 This project aims to formalize PCF theory in lean, following article 14, "Cardinal Arithmetic", in the "Handbook of Set Theory".
 This article is also a great resource for anyone who wants to learn more about this topic, starting with the very basics.


### PR DESCRIPTION
GitHub's LaTeX rendering is rather crappy, and I have to put some `\left \right`s before vertical bars to get them displayed properly in my Chrome browser on PC.

Before:
![image](https://github.com/user-attachments/assets/c7843c3c-34e3-4d8f-a2b8-de2b16d28137)
After:
![image](https://github.com/user-attachments/assets/528b150d-5383-45d8-bd46-c4200dd4deeb)
